### PR TITLE
Add support for clip skip

### DIFF
--- a/config.md
+++ b/config.md
@@ -82,6 +82,7 @@ Here you can see an explanation of what which option does
             },
             "amount": The default amount of images to generate (INTEGER) *1,
             "cfg": The cfg value to use for generation (INTEGER) *1,
+            "clip_skip": The clip_skip value to use for generation (INTEGER) *1,
             "sampler": The default sampler to use (STRING) *1 *2,
             "model": The default model to use for generation (STRING) *1 *3,
             "denoise": The default denoise strength to use in % (NUMBER; 0-100) *1,
@@ -127,6 +128,7 @@ Here you can see an explanation of what which option does
             },
             "allow_sampler": (BOOLEAN) *5
             "allow_cfg": (BOOLEAN) *5,
+            "allow_clip_skip": (BOOLEAN) *5,
             "allow_seed": (BOOLEAN) *5,
             "allow_height": (BOOLEAN) *5,
             "allow_width": (BOOLEAN) *5,

--- a/config.md
+++ b/config.md
@@ -161,6 +161,7 @@ Here you can see an explanation of what which option does
         "improve_loading_time": Try to improve the displaying time between generation finished and generation displayed in discord (BOOLEAN) *7
         "default": {
             "tiling": Whether the result should be tileable if nothing is specified (BOOLEAN) *1,
+            "clip_skip": The clip_skip value to use for generation (INTEGER) *1,
             "share:" The default for sharing the result (BOOLEAN) *1,
             "amount": The default amount of images to generate (INTEGER) *1,
             "style": The name of the style to use as a default (STRING)

--- a/src/commands/advanced_generate.ts
+++ b/src/commands/advanced_generate.ts
@@ -312,6 +312,10 @@ export default class extends Command {
             if(lora.type !== "LORA" && lora.type !== "LoCon") return ctx.error({error: "The given ID is not a LORA, LoCon or LyCORIS"})
             if(lora.modelVersions[0]?.files[0]?.sizeKB && lora.modelVersions[0]?.files[0]?.sizeKB > 225280 && !ctx.client.horde_curated_loras?.includes(lora.id)) return ctx.error({error: "The given LORA, LoCon or LyCORIS is larger than 220mb"})
         }
+        const lora_obj = lora_id ? [{
+                "name": lora_id,
+                "inject_trigger": "all"
+            }] : style?.loras ?? undefined;
 
         if(party?.channel_id) return ctx.error({error: `You can only use ${await ctx.client.getSlashCommandTag("generate")} in parties`, codeblock: false})
         if(ctx.client.config.advanced_generate?.require_login && !user_token) return ctx.error({error: `You are required to ${await ctx.client.getSlashCommandTag("login")} to use ${await ctx.client.getSlashCommandTag("advanced_generate")}`, codeblock: false})
@@ -406,7 +410,7 @@ export default class extends Command {
                 n: amount,
                 denoising_strength: denoise,
                 karras,
-                loras: lora_id ? [{name: lora_id}] : undefined,
+                loras: lora_obj,
                 tis,
                 hires_fix,
                 workflow: qr_code_url ? "qr_code" : undefined,

--- a/src/commands/advanced_generate.ts
+++ b/src/commands/advanced_generate.ts
@@ -295,9 +295,9 @@ export default class extends Command {
         const share_result = ctx.interaction.options.getBoolean("share_result") ?? ctx.client.config.advanced_generate?.default?.share
         const lora_id = ctx.interaction.options.getString("lora")
         const ti_raw = ctx.interaction.options.getString("textual_inversion") ?? ctx.client.config.advanced_generate.default?.tis
-        const hires_fix = ctx.interaction.options.getBoolean("hires_fix") ?? ctx.client.config.advanced_generate.default?.hires_fix ?? false
+        const hires_fix = ctx.interaction.options.getBoolean("hires_fix") ?? ctx.client.config.advanced_generate.default?.hires_fix ?? undefined
         const qr_code_url = ctx.interaction.options.getString("qr_code_url")
-        const clipskip = ctx.interaction.options.getInteger("clip_skip") ?? style?.clip_skip ?? ctx.client.config.advanced_generate?.default?.clip_skip ?? 1
+        const clipskip = ctx.interaction.options.getInteger("clip_skip") ?? style?.clip_skip ?? ctx.client.config.advanced_generate?.default?.clip_skip ?? undefined
         let img = ctx.interaction.options.getAttachment("source_image")
 
         const user_token = await ctx.client.getUserToken(ctx.interaction.user.id, ctx.database)

--- a/src/commands/advanced_generate.ts
+++ b/src/commands/advanced_generate.ts
@@ -295,9 +295,9 @@ export default class extends Command {
         const share_result = ctx.interaction.options.getBoolean("share_result") ?? ctx.client.config.advanced_generate?.default?.share
         const lora_id = ctx.interaction.options.getString("lora")
         const ti_raw = ctx.interaction.options.getString("textual_inversion") ?? ctx.client.config.advanced_generate.default?.tis
-        const hires_fix = ctx.interaction.options.getBoolean("hires_fix") ?? ctx.client.config.advanced_generate.default?.hires_fix ?? undefined
+        const hires_fix = ctx.interaction.options.getBoolean("hires_fix") ?? ctx.client.config.advanced_generate.default?.hires_fix
         const qr_code_url = ctx.interaction.options.getString("qr_code_url")
-        const clipskip = ctx.interaction.options.getInteger("clip_skip") ?? style?.clip_skip ?? ctx.client.config.advanced_generate?.default?.clip_skip ?? undefined
+        const clipskip = ctx.interaction.options.getInteger("clip_skip") ?? style?.clip_skip ?? ctx.client.config.advanced_generate?.default?.clip_skip
         let img = ctx.interaction.options.getAttachment("source_image")
 
         const user_token = await ctx.client.getUserToken(ctx.interaction.user.id, ctx.database)
@@ -315,7 +315,7 @@ export default class extends Command {
         const lora_obj = lora_id ? [{
                 "name": lora_id,
                 "inject_trigger": "all"
-            }] : style?.loras ?? undefined;
+            }] : style?.loras;
 
         if(party?.channel_id) return ctx.error({error: `You can only use ${await ctx.client.getSlashCommandTag("generate")} in parties`, codeblock: false})
         if(ctx.client.config.advanced_generate?.require_login && !user_token) return ctx.error({error: `You are required to ${await ctx.client.getSlashCommandTag("login")} to use ${await ctx.client.getSlashCommandTag("advanced_generate")}`, codeblock: false})

--- a/src/commands/advanced_generate.ts
+++ b/src/commands/advanced_generate.ts
@@ -287,6 +287,7 @@ export default class extends Command {
         const ti_raw = ctx.interaction.options.getString("textual_inversion") ?? ctx.client.config.advanced_generate.default?.tis
         const hires_fix = ctx.interaction.options.getBoolean("hires_fix") ?? ctx.client.config.advanced_generate.default?.hires_fix ?? false
         const qr_code_url = ctx.interaction.options.getString("qr_code_url")
+        const clipskip = style?.clip_skip ?? 1
         let img = ctx.interaction.options.getAttachment("source_image")
 
         const user_token = await ctx.client.getUserToken(ctx.interaction.user.id, ctx.database)
@@ -384,6 +385,7 @@ export default class extends Command {
             params: {
                 sampler_name: sampler,
                 cfg_scale: cfg,
+                clip_skip: clipskip,
                 seed: seed ?? undefined,
                 height,
                 width,

--- a/src/commands/advanced_generate.ts
+++ b/src/commands/advanced_generate.ts
@@ -225,10 +225,20 @@ const command_data = new SlashCommandBuilder()
                 .setDescription("The url to use for the qr code")
             )
         }
+        if(config.advanced_generate.user_restrictions?.allow_clip_skip) {
+            command_data
+            .addIntegerOption(
+                new SlashCommandIntegerOption()
+                .setName("clip_skip")
+                .setDescription("The number of CLIP language processor layers to skip")
+                .setMinValue(1) //1 is off/default
+                .setMaxValue(12)
+            )
+        }
     }
 
 
-    // 24 out of 25 options used
+    // 25 out of 25 options used(!)
 
 function generateButtons(id: string) {
     let i = 0
@@ -287,7 +297,7 @@ export default class extends Command {
         const ti_raw = ctx.interaction.options.getString("textual_inversion") ?? ctx.client.config.advanced_generate.default?.tis
         const hires_fix = ctx.interaction.options.getBoolean("hires_fix") ?? ctx.client.config.advanced_generate.default?.hires_fix ?? false
         const qr_code_url = ctx.interaction.options.getString("qr_code_url")
-        const clipskip = style?.clip_skip ?? 1
+        const clipskip = ctx.interaction.options.getInteger("clip_skip") ?? style?.clip_skip ?? ctx.client.config.advanced_generate?.default?.clip_skip ?? 1
         let img = ctx.interaction.options.getAttachment("source_image")
 
         const user_token = await ctx.client.getUserToken(ctx.interaction.user.id, ctx.database)

--- a/src/commands/generate.ts
+++ b/src/commands/generate.ts
@@ -141,8 +141,8 @@ export default class extends Command {
         let img = ctx.interaction.options.getAttachment("source_image")
 
         const style = ctx.client.getHordeStyle(style_raw)
+        const clipskip = style?.clip_skip ?? undefined
 
-        const clipskip = style?.clip_skip ?? 1
         let height = style?.height
         let width = style?.width
 

--- a/src/commands/generate.ts
+++ b/src/commands/generate.ts
@@ -141,7 +141,7 @@ export default class extends Command {
         let img = ctx.interaction.options.getAttachment("source_image")
 
         const style = ctx.client.getHordeStyle(style_raw)
-        const clipskip = style?.clip_skip ?? ctx.client.config.generate?.default?.clip_skip ?? undefined
+        const clipskip = style?.clip_skip ?? ctx.client.config.generate?.default?.clip_skip
 
         let height = style?.height
         let width = style?.width

--- a/src/commands/generate.ts
+++ b/src/commands/generate.ts
@@ -141,7 +141,7 @@ export default class extends Command {
         let img = ctx.interaction.options.getAttachment("source_image")
 
         const style = ctx.client.getHordeStyle(style_raw)
-        const clipskip = style?.clip_skip ?? undefined
+        const clipskip = style?.clip_skip ?? ctx.client.config.generate?.default?.clip_skip ?? undefined
 
         let height = style?.height
         let width = style?.width

--- a/src/commands/generate.ts
+++ b/src/commands/generate.ts
@@ -142,6 +142,7 @@ export default class extends Command {
 
         const style = ctx.client.getHordeStyle(style_raw)
 
+        const clipskip = style?.clip_skip ?? 1
         let height = style?.height
         let width = style?.width
 
@@ -224,6 +225,7 @@ export default class extends Command {
             params: {
                 sampler_name: style.sampler_name as typeof ModelGenerationInputStableSamplers[keyof typeof ModelGenerationInputStableSamplers],
                 height: height,
+                clip_skip: clipskip,
                 width: width,
                 n: amount,
                 tiling,

--- a/src/types.ts
+++ b/src/types.ts
@@ -187,6 +187,9 @@ export interface HordeStyleData {
     hires_fix?: boolean,
     loras?: {
         name: string,
+        model?: number,
+        clip?: number,
+        is_version?: boolean,
         inject_trigger?: string
     }[],
     tis?: {

--- a/src/types.ts
+++ b/src/types.ts
@@ -180,6 +180,7 @@ export interface HordeStyleData {
     model?: string,
     sampler_name?: string,
     width?: number,
+    clip_skip?: number,
     height?: number,
     steps?: number,
     cfg_scale?: number,

--- a/src/types.ts
+++ b/src/types.ts
@@ -288,6 +288,7 @@ export interface Config {
                 height?: number
             },
             cfg?: number,
+            clip_skip?: number,
             amount?: number,
             sampler?: typeof ModelGenerationInputStableSamplers,
             model?: string,
@@ -340,6 +341,7 @@ export interface Config {
             allow_style: boolean,
             allow_sampler?: boolean,
             allow_cfg?: boolean,
+            allow_clip_skip?: boolean,
             allow_seed?: boolean,
             allow_height?: boolean,
             allow_width?: boolean,

--- a/src/types.ts
+++ b/src/types.ts
@@ -381,6 +381,7 @@ export interface Config {
         convert_a1111_weight_to_horde_weight?: boolean,
         default?: {
             tiling?: boolean,
+            clip_skip?: number,
             amount?: number,
             share?: boolean,
             style?: string,

--- a/template.config.json
+++ b/template.config.json
@@ -99,6 +99,7 @@
                 "height": 512
             },
             "cfg": 7.5,
+            "clip_skip": 1,
             "amount": 1,
             "sampler": "k_euler",
             "model": "stable_diffusion",
@@ -151,6 +152,7 @@
             "allow_style": true,
             "allow_sampler": true,
             "allow_cfg": true,
+            "allow_clip_skip": true,
             "allow_seed": true,
             "allow_height": true,
             "allow_width": true,

--- a/template.config.json
+++ b/template.config.json
@@ -189,6 +189,7 @@
         "default": {
             "tiling": false,
             "amount": 1,
+            "clip_skip": 1,
             "share": false,
             "style": "raw",
             "keep_original_ratio": true,


### PR DESCRIPTION
<!-- Replace [Title] with a short summary of what this pull request is -->
# Add support for Clip Skip and extra lora fields

## Detailed Description

This PR:
1. Adds support for clip_skip
  - Applies clip_skip set in styles when using /generate
  - Applies clip_skip set in styles when using /advanced_generate
  - Adds a subcommand to set clip_skip when using /advanced_generate
  - Adds default settings for clip_skip
2. Adds support for the extra lora fields in styles in /generate
3. When user doesn't set loras in /advanced_generate, use style loras

## Why this is needed
1. clip skip is *required* for pony models, they return blurry fog without clip skip set to >1. The latest version of ICBINP is also superior with clip skip.
2. there's currently no bot support for lora versions, which are used in multiple styles
3. advanced_generate has no option to use multiple loras as required by some styles, so it's currently impossible to use them properly and tweak other settings.


## Other Info
I've used up the last available subcommand in /advanced_generate. This can be mitigated:
- One can be freed up by using logic regarding denoising and source image (if denoising is set, enable hires-fix. provide an autocomplete response of True and False that set denoising value at 65 and 0 internally, and disable hiresfix if denoise is set to 0. (65 is the default)
- One can be freed up by merging postprocessors, which will also allow adding all the possible postprocessors (rembg, choice of 5 upscalers, codeformers, gfpgan). For initial autocomplete, show all options; if there's a valid option ending with a comma, autocomplete can provide the remaining valid options (you can only have one upscaler, but it can be mixed with both face fixers and rembg). Since order of postprocessing is not customizable, number of possible responses can be reduced by not allowing arbitrary order.


